### PR TITLE
Remove step_num from Proof_System

### DIFF
--- a/Code/Macro/Proof_System.py
+++ b/Code/Macro/Proof_System.py
@@ -447,7 +447,7 @@ class Past_Config(object):
   def __repr__(self):
     return repr(self.__dict__)
 
-  def log_config(self, step_num, loop_num):
+  def log_config(self, loop_num):
     """Decide whether we should try to prove a rule.
 
     Currently, we try to prove a rule we've seen happen twice (not necessarily
@@ -575,7 +575,7 @@ class Proof_System(object):
       if found_rule:
         print()
 
-  def log_and_apply(self, tape, state, step_num, loop_num):
+  def log_and_apply(self, tape, state, loop_num):
     """
     Log this configuration into the memory and check if it is similar to a
     past one. Apply rule if possible.
@@ -584,7 +584,7 @@ class Proof_System(object):
     # Note: we ignore the number of repetitions of these sequences so that we
     #   can get a very general view of the tape.
     stripped_config = strip_config(state, tape.dir, tape.tape)
-    full_config = (state, tape, step_num, loop_num)
+    full_config = (state, tape, loop_num)
 
     # Try to apply an already proven rule.
     result = self.try_apply_a_rule(stripped_config, full_config)
@@ -598,7 +598,7 @@ class Proof_System(object):
     # Otherwise log it into past_configs and see if we should try and prove
     # a new rule.
     past_config = self.past_configs[stripped_config]
-    if past_config.log_config(step_num, loop_num):
+    if past_config.log_config(loop_num):
       # We see enough of a pattern to try and prove a rule.
       rule = self.prove_rule(stripped_config, full_config,
                              loop_num - past_config.last_loop_num)
@@ -715,7 +715,7 @@ class Proof_System(object):
     Returns rule if successful or None.
     """
     # Unpack configurations
-    new_state, new_tape, new_step_num, new_loop_num = full_config
+    new_state, new_tape, new_loop_num = full_config
 
     if self.verbose:
       print()
@@ -1020,7 +1020,7 @@ class Proof_System(object):
   def apply_rule(self, rule, start_config):
     """Try to apply a rule to a given configuration."""
     if self.verbose:
-      start_state, start_tape, start_step_num, start_loop_num = start_config
+      start_state, start_tape, start_loop_num = start_config
       print()
       self.print_this("++ Applying Rule ++")
       self.print_this("Loop:", start_loop_num, "Rule ID:", rule.name)
@@ -1038,7 +1038,7 @@ class Proof_System(object):
     elif isinstance(rule, General_Rule):
       return self.apply_general_rule(rule, start_config)
     elif isinstance(rule, Limited_Diff_Rule):
-      start_state, start_tape, start_step_num, start_loop_num = start_config
+      start_state, start_tape, start_loop_num = start_config
 
       limited_start_tape = start_tape.copy()
 
@@ -1048,7 +1048,7 @@ class Proof_System(object):
       limited_start_tape.tape[0] = limited_start_tape.tape[0][-rule.left_dist:]
       limited_start_tape.tape[1] = limited_start_tape.tape[1][-rule.right_dist:]
 
-      limited_start_config = (start_state, limited_start_tape, start_step_num, start_loop_num)
+      limited_start_config = (start_state, limited_start_tape, start_loop_num)
 
       success, other = self.apply_diff_rule(rule, limited_start_config)
 
@@ -1071,7 +1071,7 @@ class Proof_System(object):
 
   def apply_diff_rule(self, rule, start_config):
     ## Unpack input
-    new_state, new_tape, new_step_num, new_loop_num = start_config
+    new_state, new_tape, new_loop_num = start_config
     new_tape = new_tape.copy()  # Make a clean copy that we can edit here.
 
     ## Calculate number of repetitions allowable and other tape-based info.
@@ -1245,7 +1245,7 @@ class Proof_System(object):
       return self.apply_general_rule(rule.gen_rule, start_config)
 
     # Unpack input
-    start_state, start_tape, start_step_num, start_loop_num = start_config
+    start_state, start_tape, start_loop_num = start_config
     current_list = [block.num for block in start_tape.tape[0] + start_tape.tape[1]]
     assert len(current_list) == len(rule.var_list)
 
@@ -1314,7 +1314,7 @@ class Proof_System(object):
 
   def apply_exponential_rule(self, rule, start_config):
     # Unpack input
-    start_state, start_tape, start_step_num, start_loop_num = start_config
+    start_state, start_tape, start_loop_num = start_config
     current_list = [block.num for block in start_tape.tape[0] + start_tape.tape[1]]
     assert len(current_list) == len(rule.var_list)
 
@@ -1346,7 +1346,7 @@ class Proof_System(object):
       raise Exception("Not simulating General_Rule")
 
     # Unpack input
-    start_state, start_tape, start_step_num, start_loop_num = start_config
+    start_state, start_tape, start_loop_num = start_config
 
     large_delta = True  # Not edited in this function.
     # Current list of all block exponents. We will update it in place repeatedly

--- a/Code/Macro/Simulator.py
+++ b/Code/Macro/Simulator.py
@@ -139,7 +139,7 @@ class Simulator(object):
     if self.prover:
       # Log the configuration in the prover and apply rule if possible.
       prover_result = self.prover.log_and_apply(
-        self.tape, self.state, self.step_num, self.num_loops-1)
+        self.tape, self.state, self.num_loops-1)
 
       # Proof system says that machine will repeat forever
       if prover_result.condition == Proof_System.INF_REPEAT:

--- a/Code/test_Proof_System.py
+++ b/Code/test_Proof_System.py
@@ -108,7 +108,7 @@ class ProofSystemTest(unittest.TestCase):
     ]
 
     state_A = Turing_Machine.Simple_Machine_State(0)
-    full_config = (state_A, tape, None, None)
+    full_config = (state_A, tape, None)
     stripped_config = Proof_System.strip_config(
       state_A, Turing_Machine.RIGHT, tape.tape)
 
@@ -131,7 +131,7 @@ class ProofSystemTest(unittest.TestCase):
       Tape.Repeated_Symbol(0,math.inf),
       Tape.Repeated_Symbol(2, 10),
     ]
-    bad_full_config = (state_A, bad_tape, None, None)
+    bad_full_config = (state_A, bad_tape, None)
     bad_stripped_config = Proof_System.strip_config(
       state_A, Turing_Machine.RIGHT, bad_tape.tape)
 
@@ -147,8 +147,7 @@ class ProofSystemTest(unittest.TestCase):
 
     # To call "apply_rule", a "rule" and a "start_config" are needed.
 
-    # Build the "start_config".  It is a tuple contains a "state", "tape",
-    # "step_num", and "loop_num".
+    # Build the "start_config". It is a tuple containing a "state", "tape", and "loop_num".
     current_state = Turing_Machine.Simple_Machine_State(0)
 
     current_tape = Tape.Chain_Tape()
@@ -164,10 +163,9 @@ class ProofSystemTest(unittest.TestCase):
                             Tape.Repeated_Symbol(0,15),
                            ]
 
-    step_num = 10
-    loop_num =  3
+    loop_num = 3
 
-    current_config = (current_state, current_tape, step_num, loop_num)
+    current_config = (current_state, current_tape, loop_num)
 
     # Build the "Limited_Diff_Rule" which is constructed with an
     # "initial_tape", "left_dist", "right_dist", "diff_tape", "initial_state",
@@ -254,7 +252,7 @@ class ProofSystemTest(unittest.TestCase):
                    ]
 
     state_A = Turing_Machine.Simple_Machine_State(0)
-    full_config = (state_A, tape, None, None)
+    full_config = (state_A, tape, None)
     stripped_config = Proof_System.strip_config(
       state_A, Turing_Machine.RIGHT, tape.tape)
     base_rule = prover.prove_rule(stripped_config, full_config, delta_loop = 5)
@@ -291,7 +289,7 @@ class ProofSystemTest(unittest.TestCase):
                    ]
 
     state_A = Turing_Machine.Simple_Machine_State(0)
-    full_config = (state_A, tape, None, None)
+    full_config = (state_A, tape, None)
     stripped_config = Proof_System.strip_config(
       state_A, Turing_Machine.RIGHT, tape.tape)
     meta_rule = prover.prove_rule(stripped_config, full_config, delta_loop = 36)
@@ -313,7 +311,7 @@ class ProofSystemTest(unittest.TestCase):
                     Tape.Repeated_Symbol(0, 20),
                    ]
 
-    full_config = (state_A, tape, None, None)
+    full_config = (state_A, tape, None)
 
     success, rest = prover.apply_rule(meta_rule, full_config)
     self.assertTrue(success)
@@ -362,7 +360,7 @@ class ProofSystemTest(unittest.TestCase):
                    ]
 
     state_E = Turing_Machine.Simple_Machine_State(4)
-    full_config = (state_E, tape, None, None)
+    full_config = (state_E, tape, None)
     stripped_config = Proof_System.strip_config(
       state_E, Turing_Machine.LEFT, tape.tape)
     rule_d1 = prover.prove_rule(stripped_config, full_config, delta_loop = 10)
@@ -392,7 +390,7 @@ class ProofSystemTest(unittest.TestCase):
                     Tape.Repeated_Symbol(Block_Symbol((1, 1)), 20),
                    ]
 
-    full_config = (state_E, tape, None, None)
+    full_config = (state_E, tape, None)
     stripped_config = Proof_System.strip_config(
       state_E, Turing_Machine.LEFT, tape.tape)
     rule_d2 = prover.prove_rule(stripped_config, full_config, delta_loop = 10)
@@ -423,7 +421,7 @@ class ProofSystemTest(unittest.TestCase):
                     Tape.Repeated_Symbol(Block_Symbol((1, 1)), 20),
                    ]
 
-    full_config = (state_E, tape, None, None)
+    full_config = (state_E, tape, None)
     stripped_config = Proof_System.strip_config(
       state_E, Turing_Machine.LEFT, tape.tape)
     rule_linear = prover.prove_rule(stripped_config, full_config, delta_loop = 28)
@@ -455,7 +453,7 @@ class ProofSystemTest(unittest.TestCase):
                     Tape.Repeated_Symbol(Block_Symbol((1, 1)), 10),
                    ]
 
-    full_config = (state_E, tape, None, None)
+    full_config = (state_E, tape, None)
     stripped_config = Proof_System.strip_config(
       state_E, Turing_Machine.LEFT, tape.tape)
     rule_meta = prover.prove_rule(stripped_config, full_config, delta_loop = 68)


### PR DESCRIPTION
`Quick_Sim.py` still works:
```
python Quick_Sim.py '1RB---_0RC0RE_1RD1RF_1LE0LB_1RC0LD_1RC1RA' --block-size=2 --max-loops=300000 --print-loops=300000
...
         Steps:                     Times Applied:
Total:   ~10^9_876.51297                    300000
Macro:   855_384                            205679
Chain:   ~10^4_939.50942                     82649
Rule:    ~10^9_876.51297                     11672
```