### PR TITLE
Bodgy fix to allow Quick_Sim to run

### DIFF
--- a/Code/Quick_Sim.py
+++ b/Code/Quick_Sim.py
@@ -13,6 +13,7 @@ import Exp_Int
 import Halting_Lib
 from Halting_Lib import big_int_approx_and_full_str
 import IO
+import globals
 
 import io_pb2
 
@@ -217,6 +218,8 @@ if __name__ == "__main__":
 
   if options.max_loops and options.print_loops > options.max_loops:
     options.print_loops = options.max_loops
+
+  globals.init()
 
   if len(args) != 1:
     parser.error("Must have at least one argument, machine_file")


### PR DESCRIPTION
When I try and run the command ``python Code/Quick_Sim.py Machines/3x3-Bigfoot`` from the command line, I get an error that globals.time_remaining is not defined. On inspection, globals appears to be some kind of store for variables that's called in testing files, but is not called when trying to run one of the Python Libraries directly from the command line.

I just took the most direct approach - initialise globals in the __init__ section of Quick_Sim.py. I haven't investigated the code deeply enough to understand the full purpose of globals and whether there's a better approach to making the error go away (hence the title), and it's entirely possible there's a different 'intended' solution, in which case feel free to reject the pull request and implement the intended solution instead. However, I know this way fixes the problem, which is good enough for me.

On the other hand, if this is the correct fix, then I'm guessing other __init__ code sections may need to have the globals variable initialised as well.